### PR TITLE
Add install rules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,18 +4,110 @@
 #https://www.boost.org/LICENSE_1_0.txt)
 #Official repository: https://github.com/fgoujeon/maki
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.23)
 
-project(maki)
+project(maki VERSION 1.0.1 LANGUAGES CXX)
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
 
 option(MAKI_BUILD_EXAMPLES "Build example executables" OFF)
 option(MAKI_BUILD_TESTS "Build test executable" OFF)
 option(MAKI_FORCE_CATCH2_V2 "Force version 2 of catch2" OFF)
+option(MAKI_INSTALL "Install the library" ON)
 
 add_library(maki INTERFACE)
-target_include_directories(maki INTERFACE include)
+target_sources(maki
+     INTERFACE
+     FILE_SET HEADERS
+     BASE_DIRS include
+     FILES
+         include/maki.hpp
+         include/maki/action.hpp
+         include/maki/context.hpp
+         include/maki/event.hpp
+         include/maki/event_set.hpp
+         include/maki/events.hpp
+         include/maki/fin.hpp
+         include/maki/guard.hpp
+         include/maki/ini.hpp
+         include/maki/machine.hpp
+         include/maki/machine_conf.hpp
+         include/maki/machine_ref.hpp
+         include/maki/machine_ref_conf.hpp
+         include/maki/null.hpp
+         include/maki/path.hpp
+         include/maki/region.hpp
+         include/maki/state.hpp
+         include/maki/state_mold.hpp
+         include/maki/state_set.hpp
+         include/maki/states.hpp
+         include/maki/transition_table.hpp
+         include/maki/version.hpp
+         # detail/
+         include/maki/detail/call.hpp
+         include/maki/detail/conf_traits.hpp
+         include/maki/detail/constant.hpp
+         include/maki/detail/context_holder.hpp
+         include/maki/detail/equals.hpp
+         include/maki/detail/event_action.hpp
+         include/maki/detail/function_queue.hpp
+         include/maki/detail/impl.hpp
+         include/maki/detail/integer_constant_sequence.hpp
+         include/maki/detail/machine_conf_fwd.hpp
+         include/maki/detail/maybe_bool_util.hpp
+         include/maki/detail/noinline.hpp
+         include/maki/detail/overload_priority.hpp
+         include/maki/detail/path.hpp
+         include/maki/detail/pretty_name.hpp
+         include/maki/detail/region.hpp
+         include/maki/detail/region_fwd.hpp
+         include/maki/detail/set.hpp
+         include/maki/detail/signature_macros.hpp
+         include/maki/detail/state_id_to_type.hpp
+         include/maki/detail/state_id_traits.hpp
+         include/maki/detail/state_mold_fwd.hpp
+         include/maki/detail/state_type_list_filters.hpp
+         include/maki/detail/tlu.hpp
+         include/maki/detail/transition_table_digest.hpp
+         include/maki/detail/transition_table_filters.hpp
+         include/maki/detail/tuple.hpp
+         include/maki/detail/type.hpp
+         include/maki/detail/type_list.hpp
+         include/maki/detail/type_name.hpp
+         include/maki/detail/type_traits.hpp
+         # detail/state_impls/
+         include/maki/detail/state_impls/composite.hpp
+         include/maki/detail/state_impls/composite_fwd.hpp
+         include/maki/detail/state_impls/composite_no_context.hpp
+         include/maki/detail/state_impls/composite_no_context_fwd.hpp
+         include/maki/detail/state_impls/simple.hpp
+         include/maki/detail/state_impls/simple_fwd.hpp
+         include/maki/detail/state_impls/simple_no_context.hpp
+         include/maki/detail/state_impls/simple_no_context_fwd.hpp
+         # detail/tlu/
+         include/maki/detail/tlu/apply.hpp
+         include/maki/detail/tlu/back.hpp
+         include/maki/detail/tlu/contains.hpp
+         include/maki/detail/tlu/contains_if.hpp
+         include/maki/detail/tlu/empty.hpp
+         include/maki/detail/tlu/filter.hpp
+         include/maki/detail/tlu/find.hpp
+         include/maki/detail/tlu/find_if.hpp
+         include/maki/detail/tlu/find_if_or.hpp
+         include/maki/detail/tlu/for_each.hpp
+         include/maki/detail/tlu/for_each_or.hpp
+         include/maki/detail/tlu/front.hpp
+         include/maki/detail/tlu/get.hpp
+         include/maki/detail/tlu/left_fold.hpp
+         include/maki/detail/tlu/pop_front.hpp
+         include/maki/detail/tlu/push_back.hpp
+         include/maki/detail/tlu/push_back_if.hpp
+         include/maki/detail/tlu/push_back_unique.hpp
+         include/maki/detail/tlu/push_front.hpp
+         include/maki/detail/tlu/size.hpp)
+target_compile_features(maki INTERFACE cxx_std_17)
 
 if(MAKI_BUILD_TESTS)
     find_package(Catch2 REQUIRED)
@@ -28,4 +120,13 @@ endif()
 if(MAKI_BUILD_TESTS)
     enable_testing()
     add_subdirectory(tests)
+endif()
+
+if(MAKI_INSTALL)
+    install(EXPORT maki_export DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/maki NAMESPACE maki:: FILE maki-targets.cmake)
+    install(TARGETS maki EXPORT maki_export FILE_SET HEADERS)
+
+    configure_package_config_file(${PROJECT_SOURCE_DIR}/cmake/maki-config.cmake.in ${PROJECT_BINARY_DIR}/maki-config.cmake INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/maki NO_CHECK_REQUIRED_COMPONENTS_MACRO)
+    write_basic_package_version_file(${PROJECT_BINARY_DIR}/maki-config-version.cmake VERSION ${PROJECT_VERSION} COMPATIBILITY ExactVersion)
+    install(FILES ${PROJECT_BINARY_DIR}/maki-config.cmake ${PROJECT_BINARY_DIR}/maki-config-version.cmake DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/maki)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,15 +111,13 @@ target_compile_features(maki INTERFACE cxx_std_17)
 
 if(MAKI_BUILD_TESTS)
     find_package(Catch2 REQUIRED)
+
+    enable_testing()
+    add_subdirectory(tests)
 endif()
 
 if(MAKI_BUILD_EXAMPLES)
     add_subdirectory(examples)
-endif()
-
-if(MAKI_BUILD_TESTS)
-    enable_testing()
-    add_subdirectory(tests)
 endif()
 
 if(MAKI_INSTALL)

--- a/cmake/maki-config.cmake.in
+++ b/cmake/maki-config.cmake.in
@@ -1,0 +1,5 @@
+@PROJECT_INIT@
+
+if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/maki-targets.cmake")
+  include ("${CMAKE_CURRENT_LIST_DIR}/maki-targets.cmake")
+endif()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -4,8 +4,6 @@
 #https://www.boost.org/LICENSE_1_0.txt)
 #Official repository: https://github.com/fgoujeon/maki
 
-cmake_minimum_required(VERSION 3.10)
-
 file(GLOB_RECURSE SUBDIRS LIST_DIRECTORIES true *)
 foreach(SUBDIR ${SUBDIRS})
     if(EXISTS ${SUBDIR}/CMakeLists.txt)

--- a/examples/doc/concepts/action/CMakeLists.txt
+++ b/examples/doc/concepts/action/CMakeLists.txt
@@ -4,8 +4,6 @@
 #https://www.boost.org/LICENSE_1_0.txt)
 #Official repository: https://github.com/fgoujeon/maki
 
-cmake_minimum_required(VERSION 3.10)
-
 include(maki)
 
 set(TARGET example-doc-concepts-action)

--- a/examples/doc/concepts/event/CMakeLists.txt
+++ b/examples/doc/concepts/event/CMakeLists.txt
@@ -4,8 +4,6 @@
 #https://www.boost.org/LICENSE_1_0.txt)
 #Official repository: https://github.com/fgoujeon/maki
 
-cmake_minimum_required(VERSION 3.10)
-
 include(maki)
 
 set(TARGET example-doc-concepts-event)

--- a/examples/doc/concepts/guard/CMakeLists.txt
+++ b/examples/doc/concepts/guard/CMakeLists.txt
@@ -4,8 +4,6 @@
 #https://www.boost.org/LICENSE_1_0.txt)
 #Official repository: https://github.com/fgoujeon/maki
 
-cmake_minimum_required(VERSION 3.10)
-
 include(maki)
 
 set(TARGET example-doc-concepts-guard)

--- a/examples/doc/concepts/region/CMakeLists.txt
+++ b/examples/doc/concepts/region/CMakeLists.txt
@@ -4,8 +4,6 @@
 #https://www.boost.org/LICENSE_1_0.txt)
 #Official repository: https://github.com/fgoujeon/maki
 
-cmake_minimum_required(VERSION 3.10)
-
 include(maki)
 
 set(TARGET example-doc-concepts-region)

--- a/examples/doc/concepts/run-to-completion/nok/CMakeLists.txt
+++ b/examples/doc/concepts/run-to-completion/nok/CMakeLists.txt
@@ -4,8 +4,6 @@
 #https://www.boost.org/LICENSE_1_0.txt)
 #Official repository: https://github.com/fgoujeon/maki
 
-cmake_minimum_required(VERSION 3.10)
-
 include(maki)
 
 set(TARGET example-doc-concepts-run-to-completion-nok)

--- a/examples/doc/concepts/run-to-completion/ok/CMakeLists.txt
+++ b/examples/doc/concepts/run-to-completion/ok/CMakeLists.txt
@@ -4,8 +4,6 @@
 #https://www.boost.org/LICENSE_1_0.txt)
 #Official repository: https://github.com/fgoujeon/maki
 
-cmake_minimum_required(VERSION 3.10)
-
 include(maki)
 
 set(TARGET example-doc-concepts-run-to-completion-ok)

--- a/examples/doc/concepts/state-machine/CMakeLists.txt
+++ b/examples/doc/concepts/state-machine/CMakeLists.txt
@@ -4,8 +4,6 @@
 #https://www.boost.org/LICENSE_1_0.txt)
 #Official repository: https://github.com/fgoujeon/maki
 
-cmake_minimum_required(VERSION 3.10)
-
 include(maki)
 
 set(TARGET example-doc-concepts-state-machine)

--- a/examples/doc/concepts/state/CMakeLists.txt
+++ b/examples/doc/concepts/state/CMakeLists.txt
@@ -4,8 +4,6 @@
 #https://www.boost.org/LICENSE_1_0.txt)
 #Official repository: https://github.com/fgoujeon/maki
 
-cmake_minimum_required(VERSION 3.10)
-
 include(maki)
 
 set(TARGET example-doc-concepts-state)

--- a/examples/doc/concepts/transition/CMakeLists.txt
+++ b/examples/doc/concepts/transition/CMakeLists.txt
@@ -4,8 +4,6 @@
 #https://www.boost.org/LICENSE_1_0.txt)
 #Official repository: https://github.com/fgoujeon/maki
 
-cmake_minimum_required(VERSION 3.10)
-
 include(maki)
 
 set(TARGET example-doc-concepts-transition)

--- a/examples/doc/extra/circular-dependency/machine_ref/CMakeLists.txt
+++ b/examples/doc/extra/circular-dependency/machine_ref/CMakeLists.txt
@@ -4,8 +4,6 @@
 #https://www.boost.org/LICENSE_1_0.txt)
 #Official repository: https://github.com/fgoujeon/maki
 
-cmake_minimum_required(VERSION 3.10)
-
 include(maki)
 
 set(TARGET example-doc-extra-circular-dependency-machine_ref)

--- a/examples/doc/extra/circular-dependency/template/CMakeLists.txt
+++ b/examples/doc/extra/circular-dependency/template/CMakeLists.txt
@@ -4,8 +4,6 @@
 #https://www.boost.org/LICENSE_1_0.txt)
 #Official repository: https://github.com/fgoujeon/maki
 
-cmake_minimum_required(VERSION 3.10)
-
 include(maki)
 
 set(TARGET example-doc-extra-circular-dependency-template)

--- a/examples/doc/extra/context/machine/CMakeLists.txt
+++ b/examples/doc/extra/context/machine/CMakeLists.txt
@@ -4,8 +4,6 @@
 #https://www.boost.org/LICENSE_1_0.txt)
 #Official repository: https://github.com/fgoujeon/maki
 
-cmake_minimum_required(VERSION 3.10)
-
 include(maki)
 
 set(TARGET example-doc-extra-context-machine)

--- a/examples/doc/extra/context/state/CMakeLists.txt
+++ b/examples/doc/extra/context/state/CMakeLists.txt
@@ -4,8 +4,6 @@
 #https://www.boost.org/LICENSE_1_0.txt)
 #Official repository: https://github.com/fgoujeon/maki
 
-cmake_minimum_required(VERSION 3.10)
-
 include(maki)
 
 set(TARGET example-doc-extra-context-state)

--- a/examples/doc/extra/event-set/as-action-filter/CMakeLists.txt
+++ b/examples/doc/extra/event-set/as-action-filter/CMakeLists.txt
@@ -4,8 +4,6 @@
 #https://www.boost.org/LICENSE_1_0.txt)
 #Official repository: https://github.com/fgoujeon/maki
 
-cmake_minimum_required(VERSION 3.10)
-
 include(maki)
 
 set(TARGET example-doc-extra-event-set-as-action-filter)

--- a/examples/doc/extra/event-set/in-transition-table/CMakeLists.txt
+++ b/examples/doc/extra/event-set/in-transition-table/CMakeLists.txt
@@ -4,8 +4,6 @@
 #https://www.boost.org/LICENSE_1_0.txt)
 #Official repository: https://github.com/fgoujeon/maki
 
-cmake_minimum_required(VERSION 3.10)
-
 include(maki)
 
 set(TARGET example-doc-extra-event-set-in-transition-table)

--- a/examples/doc/extra/exception-safety/CMakeLists.txt
+++ b/examples/doc/extra/exception-safety/CMakeLists.txt
@@ -4,8 +4,6 @@
 #https://www.boost.org/LICENSE_1_0.txt)
 #Official repository: https://github.com/fgoujeon/maki
 
-cmake_minimum_required(VERSION 3.10)
-
 include(maki)
 
 set(TARGET example-doc-extra-exception-safety)

--- a/examples/doc/extra/guard-composition/CMakeLists.txt
+++ b/examples/doc/extra/guard-composition/CMakeLists.txt
@@ -4,8 +4,6 @@
 #https://www.boost.org/LICENSE_1_0.txt)
 #Official repository: https://github.com/fgoujeon/maki
 
-cmake_minimum_required(VERSION 3.10)
-
 include(maki)
 
 set(TARGET example-doc-extra-guard-composition)

--- a/examples/doc/extra/hook/external-transition-decomposition/CMakeLists.txt
+++ b/examples/doc/extra/hook/external-transition-decomposition/CMakeLists.txt
@@ -4,8 +4,6 @@
 #https://www.boost.org/LICENSE_1_0.txt)
 #Official repository: https://github.com/fgoujeon/maki
 
-cmake_minimum_required(VERSION 3.10)
-
 include(maki)
 
 set(TARGET example-doc-extra-hook-external-transition-decomposition)

--- a/examples/doc/extra/hook/external-transition/CMakeLists.txt
+++ b/examples/doc/extra/hook/external-transition/CMakeLists.txt
@@ -4,8 +4,6 @@
 #https://www.boost.org/LICENSE_1_0.txt)
 #Official repository: https://github.com/fgoujeon/maki
 
-cmake_minimum_required(VERSION 3.10)
-
 include(maki)
 
 set(TARGET example-doc-extra-hook-external-transition)

--- a/examples/doc/extra/hook/processing/CMakeLists.txt
+++ b/examples/doc/extra/hook/processing/CMakeLists.txt
@@ -4,8 +4,6 @@
 #https://www.boost.org/LICENSE_1_0.txt)
 #Official repository: https://github.com/fgoujeon/maki
 
-cmake_minimum_required(VERSION 3.10)
-
 include(maki)
 
 set(TARGET example-doc-extra-hook-processing)

--- a/examples/doc/extra/state-set/CMakeLists.txt
+++ b/examples/doc/extra/state-set/CMakeLists.txt
@@ -4,8 +4,6 @@
 #https://www.boost.org/LICENSE_1_0.txt)
 #Official repository: https://github.com/fgoujeon/maki
 
-cmake_minimum_required(VERSION 3.10)
-
 include(maki)
 
 set(TARGET example-doc-extra-state-set)

--- a/examples/doc/misc/external-transition-hook/CMakeLists.txt
+++ b/examples/doc/misc/external-transition-hook/CMakeLists.txt
@@ -4,8 +4,6 @@
 #https://www.boost.org/LICENSE_1_0.txt)
 #Official repository: https://github.com/fgoujeon/maki
 
-cmake_minimum_required(VERSION 3.10)
-
 include(maki)
 
 set(TARGET example-doc-misc-external-transition-hook)

--- a/examples/rgb-lamp/CMakeLists.txt
+++ b/examples/rgb-lamp/CMakeLists.txt
@@ -4,8 +4,6 @@
 #https://www.boost.org/LICENSE_1_0.txt)
 #Official repository: https://github.com/fgoujeon/maki
 
-cmake_minimum_required(VERSION 3.10)
-
 include(maki)
 
 set(TARGET example-rgb-lamp)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,8 +4,6 @@
 #https://www.boost.org/LICENSE_1_0.txt)
 #Official repository: https://github.com/fgoujeon/maki
 
-cmake_minimum_required(VERSION 3.10)
-
 add_subdirectory(tests)
 add_subdirectory(example-checker)
 

--- a/tests/example-checker/CMakeLists.txt
+++ b/tests/example-checker/CMakeLists.txt
@@ -4,8 +4,6 @@
 #https://www.boost.org/LICENSE_1_0.txt)
 #Official repository: https://github.com/fgoujeon/maki
 
-cmake_minimum_required(VERSION 3.10)
-
 include(maki)
 
 set(TARGET example-checker)

--- a/tests/tests/CMakeLists.txt
+++ b/tests/tests/CMakeLists.txt
@@ -4,8 +4,6 @@
 #https://www.boost.org/LICENSE_1_0.txt)
 #Official repository: https://github.com/fgoujeon/maki
 
-cmake_minimum_required(VERSION 3.10)
-
 include(maki)
 
 set(TARGET maki-test)


### PR DESCRIPTION
A client now use the library with:

find_package(maki CONFIG REQUIRED)
...
target_link_libraries(tgt maki::maki)